### PR TITLE
Fix game saving bug

### DIFF
--- a/Classes/Pokemon.gd
+++ b/Classes/Pokemon.gd
@@ -9,7 +9,7 @@ var uuid = preload("res://uuid.gd").new();
 func _init(poke: Dictionary = {}, enemy = false, levels = [1, 100], for_battle = true):
 	if("name" in poke):
 		name = poke.name;
-		data = poke;
+		data = poke.duplicate(true);
 		#EXTRA PROPS
 		get_extra_props();
 		#ASSETS


### PR DESCRIPTION
Without this fix battle_scene.gd at line 647 throws the following error after loading a saved game: `Invalid access to property or key 'sprites' on a base object of type 'Dictionary'`

The reason is that without using duplicate is using a reference, meaning it replaces `LIBRARIES.POKEDEX.LIST[9]` when running `animated_sprite.instantiate()`, that creates an issue on the next load because get_poke_resources will not enter the if statement evaluating `resources.sprites.begins_with("res://"))`